### PR TITLE
feat(quex): add OnStop hook invoked when a worker terminates

### DIFF
--- a/quex/worker.go
+++ b/quex/worker.go
@@ -46,6 +46,17 @@ type StartWorkerOptions struct {
 	// ReconnectBackOff defines the backoff strategy for reconnection attempts.
 	// If nil, DefaultReconnectBackOffFactory() will be used.
 	ReconnectBackOff backoff.BackOff
+
+	// OnStop, when set, is invoked exactly once when the worker goroutine
+	// exits. Its argument is the real Worker.Run() failure when the worker
+	// terminated abnormally (the reconnect backoff gave up, or a worker could
+	// not be recreated), or nil on a clean Stop(). It is the real run error
+	// rather than the generic ErrReconnectBackOffStopped that Err() reports.
+	//
+	// Worker death happens in the lock loop, outside the Perform function, so
+	// it is invisible to per-job instrumentation; OnStop is the hook to wire
+	// error reporting (e.g. an error notifier) without coupling quex to it.
+	OnStop func(err error)
 }
 
 // StartWorkerOption represents an option function for configuring a worker.
@@ -62,6 +73,14 @@ func WithLogger(logger *slog.Logger) StartWorkerOption {
 func WithReconnectBackOff(b backoff.BackOff) StartWorkerOption {
 	return func(opts *StartWorkerOptions) {
 		opts.ReconnectBackOff = b
+	}
+}
+
+// WithOnStop sets the callback invoked once when the worker stops. See
+// StartWorkerOptions.OnStop.
+func WithOnStop(fn func(err error)) StartWorkerOption {
+	return func(opts *StartWorkerOptions) {
+		opts.OnStop = fn
 	}
 }
 
@@ -112,12 +131,26 @@ func StartWorker(ctx context.Context, workerOptions que.WorkerOptions, options .
 	// Start a goroutine to run the worker
 	go func() (xerr error) {
 		defer close(workerDoneC)
+		// lastRunErr holds the most recent Worker.Run() error. On terminal exit
+		// it is the real cause to report — xerr is often the generic
+		// ErrReconnectBackOffStopped wrapper, which hides what actually broke.
+		var lastRunErr error
 		// Ensure worker lifecycle ends when goroutine exits for any reason
 		defer func() {
 			if xerr != nil {
 				logger.ErrorContext(workerCtx, "Worker stopped with error", "error", xerr)
 			} else {
 				logger.InfoContext(workerCtx, "Worker stopped")
+			}
+			if opts.OnStop != nil {
+				var cause error
+				if xerr != nil {
+					cause = xerr
+					if lastRunErr != nil {
+						cause = lastRunErr
+					}
+				}
+				opts.OnStop(cause)
 			}
 			workerCancel(xerr)
 		}()
@@ -135,6 +168,7 @@ func StartWorker(ctx context.Context, workerOptions que.WorkerOptions, options .
 			if errors.Is(err, que.ErrWorkerStoped) {
 				return nil
 			}
+			lastRunErr = err
 
 			logger.WarnContext(workerCtx, "Worker error, will attempt to recreate", "error", err)
 

--- a/quex/worker_test.go
+++ b/quex/worker_test.go
@@ -1,0 +1,111 @@
+package quex_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/pkg/errors"
+	que "github.com/qor5/go-que"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qor5/go-bus/quex"
+)
+
+// recordingOnStop captures the OnStop callback invocations.
+type recordingOnStop struct {
+	mu    sync.Mutex
+	calls []error
+}
+
+func (r *recordingOnStop) fn(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, err)
+}
+
+func (r *recordingOnStop) Calls() []error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]error(nil), r.calls...)
+}
+
+// failingMutex makes every Lock fail, so Worker.Run() returns an error.
+type failingMutex struct{}
+
+func (failingMutex) Lock(_ context.Context, _ string, _ int) ([]que.Job, error) {
+	return nil, errors.New("simulated lock failure")
+}
+func (failingMutex) Unlock(_ context.Context, _ []int64) error { return nil }
+
+// idleMutex never returns jobs and never errors, so the worker idles until Stop.
+type idleMutex struct{}
+
+func (idleMutex) Lock(_ context.Context, _ string, _ int) ([]que.Job, error) { return nil, nil }
+func (idleMutex) Unlock(_ context.Context, _ []int64) error                  { return nil }
+
+func noopPerform(_ context.Context, _ que.Job) error { return nil }
+
+// TestStartWorker_OnStopReportsRealErrorOnAbnormalTermination verifies that
+// when the worker gives up, OnStop fires once carrying the real Run() error
+// (not the generic ErrReconnectBackOffStopped that Err() reports).
+func TestStartWorker_OnStopReportsRealErrorOnAbnormalTermination(t *testing.T) {
+	rec := &recordingOnStop{}
+	ctrl, err := quex.StartWorker(context.Background(), que.WorkerOptions{
+		Queue:                     "test-queue",
+		Mutex:                     failingMutex{},
+		Perform:                   noopPerform,
+		MaxLockPerSecond:          100,
+		MaxPerformPerSecond:       100,
+		MaxConcurrentPerformCount: 1,
+	},
+		quex.WithReconnectBackOff(&backoff.StopBackOff{}), // give up on first failure
+		quex.WithOnStop(rec.fn),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = ctrl.Stop(ctx)
+	})
+
+	select {
+	case <-ctrl.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker should give up and close Done()")
+	}
+	require.Error(t, ctrl.Err())
+
+	calls := rec.Calls()
+	require.Len(t, calls, 1, "OnStop must fire exactly once on terminal failure")
+	require.Error(t, calls[0])
+	require.ErrorContains(t, calls[0], "simulated lock failure",
+		"OnStop must carry the real Run() error, not ErrReconnectBackOffStopped")
+}
+
+// TestStartWorker_OnStopNilOnCleanStop verifies a graceful Stop() invokes
+// OnStop once with a nil error.
+func TestStartWorker_OnStopNilOnCleanStop(t *testing.T) {
+	rec := &recordingOnStop{}
+	ctrl, err := quex.StartWorker(context.Background(), que.WorkerOptions{
+		Queue:                     "test-queue",
+		Mutex:                     idleMutex{},
+		Perform:                   noopPerform,
+		MaxLockPerSecond:          100,
+		MaxPerformPerSecond:       100,
+		MaxConcurrentPerformCount: 1,
+	}, quex.WithOnStop(rec.fn))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, ctrl.Stop(ctx))
+	<-ctrl.Done()
+	require.NoError(t, ctrl.Err())
+
+	calls := rec.Calls()
+	require.Len(t, calls, 1, "OnStop must fire once on clean stop")
+	require.NoError(t, calls[0], "clean stop must report a nil error")
+}


### PR DESCRIPTION
## Why

A supervised worker's death happens in the lock loop, **outside** the `Perform` function — so it is invisible to per-job instrumentation like `goquex.PerformWithTracing`. A queue can go dark with nothing but a `slog` line; nobody is paged.

## What

Add `WithOnStop(func(err error))` to `quex.StartWorker`, invoked **exactly once** when the worker goroutine exits:

- On abnormal termination (reconnect backoff gave up, or a worker could not be recreated) the argument is the **real `Worker.Run()` error** — not the generic `ErrReconnectBackOffStopped` wrapper that `Err()` returns, which hides what actually broke.
- On a clean `Stop()` it is invoked with `nil`.

A plain callback keeps quex **decoupled** from any specific reporting library — callers wire their own error notifier (e.g. appkit `errornotifier`) in the closure. Pairs with `WithReconnectBackOff(&backoff.StopBackOff{})` for fail-fast workers.

No new module dependency.

## Test plan

`quex/worker_test.go` (new — quex had no tests):
- failing-Lock worker + `StopBackOff` → `Done()` closes, `Err()` non-nil, `OnStop` fires exactly once carrying the real lock error (not `ErrReconnectBackOffStopped`)
- idle worker + graceful `Stop()` → `OnStop` fires once with `nil`

`go test ./quex/`, `go vet ./quex/`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)