### PR TITLE
ci: drop persisted Git credentials in actions/checkout (Aikido)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
## Summary

Aikido flags `actions/checkout` for leaving the job token in `.git/config` (`http.extraheader`) after checkout, where any later step — including third-party actions — can read it.

Added `persist-credentials: false` to `.github/workflows/go.yml`.

go.yml only runs golangci-lint, go build and go test. All module dependencies (qor5/*, theplant/*) resolve through the public module proxy, not git. Nothing uses the ambient git credential. So this is a no-op for CI behaviour.

## Aikido Issue Resolved

- [374028316](https://app.aikido.dev/issues/33607621/detail?singleIssueFilter=374028316&status=open) — GitHub Action actions/checkout persist Git credentials in workflow

Part of Aikido group [33607621](https://app.aikido.dev/issues/33607621/detail?status=open), which spans 10 workflows across 6 qor5 repos.

## Verification

- Workflow file parses as valid YAML
- No source changes — CI on this PR exercises the modified workflow directly