### PR TITLE
ci: stop actions/checkout persisting the GITHUB_TOKEN (Aikido)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
## Summary

`persist-credentials: false` on the `actions/checkout` step in
`.github/workflows/go.yml`.

Supersedes #28, which is closed in favour of this PR (same commits, replayed
on the current default branch).

## Why

`actions/checkout` v2+ writes the job's `GITHUB_TOKEN` into the repository's local
git config (`http.<url>.extraheader`) unless `persist-credentials: false` is set.
The credential is implicit — no step declares it — so every later step in the
job, including any third-party action, can read it straight out of git config.

## Token availability — checked, nothing loses access

Every fixed step was checked for a real consumer of the persisted credential in
a step *after* the checkout: a `git push`/`fetch`/`ls-remote`, a push-type
third-party action, or a private-dependency install resolving through a git
rewrite. This repository is public, so anonymous reads keep working regardless;
only a write would need the credential.

## Verification

```
python3 check_checkout_credentials_persisted.py .github/workflows
ok: every actions/checkout under .github/workflows/ sets persist-credentials: false
```

Re-verified with a real YAML parser as well: the file parses, no job or step was
lost, and `persist-credentials` is a boolean `false`.
